### PR TITLE
Replace macro for empty middleware chain

### DIFF
--- a/src/api/r0/versions.rs
+++ b/src/api/r0/versions.rs
@@ -1,19 +1,25 @@
 //! Endpoints for information about supported versions of the Matrix spec.
 
-use iron::{Handler, IronResult, Request, Response, status};
+use iron::{Chain, Handler, IronResult, Request, Response, status};
 
+use middleware::MiddlewareChain;
 use modifier::SerializableResponse;
 
-/// The /versions endpoint.
+/// The `/versions` endpoint.
+pub struct Versions;
+
+/// Endpoint's response.
 #[derive(Serialize)]
-pub struct Versions {
+struct VersionsResponse {
     versions: Vec<&'static str>,
 }
 
-impl Versions {
+middleware_chain!(Versions);
+
+impl VersionsResponse {
     /// Returns the list of supported `Versions` of the Matrix spec.
     pub fn supported() -> Self {
-        Versions {
+        VersionsResponse {
             versions: vec![
                 "r0.2.0"
             ]
@@ -23,6 +29,6 @@ impl Versions {
 
 impl Handler for Versions {
     fn handle(&self, _request: &mut Request) -> IronResult<Response> {
-        Ok(Response::with((status::Ok, SerializableResponse(&self))))
+        Ok(Response::with((status::Ok, SerializableResponse(VersionsResponse::supported()))))
     }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -24,7 +24,15 @@ pub use self::path_params::{
 /// `middleware_chain!(JoinRoom, []);`
 #[macro_export]
 macro_rules! middleware_chain {
-    ($chain:ident) => {chain_impl!($chain, []);};
+    ($chain:ident) => {
+        impl MiddlewareChain for $chain {
+            /// Create a `$chain` without any middleware.
+            fn chain() -> Chain {
+                Chain::new($chain)
+            }
+        }
+    };
+
     ($chain:ident, [$($middleware:expr),*]) => {
         impl MiddlewareChain for $chain {
             /// Create a `$chain` with all necessary middleware.

--- a/src/server.rs
+++ b/src/server.rs
@@ -160,7 +160,7 @@ impl<'a> Server<'a> {
 
         let mut versions_router = Router::new();
 
-        versions_router.get("/versions", Versions::supported(), "versions");
+        versions_router.get("/versions", Versions::chain(), "versions");
 
         let mut versions = Chain::new(versions_router);
         versions.link_after(ResponseHeaders);


### PR DESCRIPTION
It replaces the current outdated implementation from an old iteration.
The recursive approach with an empty array was not used to avoid the
`variable does not need to be mutable` warning.